### PR TITLE
Crypto init on first connect

### DIFF
--- a/.github/workflows/hubot-demo.yml
+++ b/.github/workflows/hubot-demo.yml
@@ -21,15 +21,15 @@ jobs:
       HUBOT_FAREWELL_MESSAGE: "Goodbye from GHA Hubot demo"
       HUBOT_FAREWELL_TARGET: ${{ secrets.TEST_MATRIX_ROOM }}
       HUBOT_FAREWELL_TIMEIN: 5000
-      HUBOT_FAREWELL_TIMEOUT: 30000
-      # HUBOT_LOG_LEVEL: debug
-      HUBOT_NAME: 'HubotMatrixTest'
+      HUBOT_FAREWELL_TIMEOUT: 60000
+      HUBOT_LOG_LEVEL: debug
+      HUBOT_NAME: GHA_HubotDemo_${{ github.run_id }}
       HUBOT_MATRIX_HOST: ${{ secrets.TEST_MATRIX_URL }}
       HUBOT_MATRIX_PASSWORD: ${{ secrets.TEST_MATRIX_PASSWORD }}
       HUBOT_MATRIX_USER: ${{ secrets.TEST_MATRIX_USER }}
       HUBOT_STARTUP_MESSAGE: "Hello from GHA Hubot demo"
       HUBOT_STARTUP_ROOM: ${{ secrets.TEST_MATRIX_ROOM }}
-      # LOG_LEVEL: debug
+      LOG_LEVEL: debug
 
     steps:
     - uses: actions/checkout@v2
@@ -56,7 +56,6 @@ jobs:
         npm install --save github:xurizaemon/hubot-farewell github:xurizaemon/hubot-startup
         echo '["@xurizaemon/hubot-farewell", "@xurizaemon/hubot-startup"]' > external-scripts.json
         echo "PATH=$PATH:$( pwd )/node_modules/.bin" >> $GITHUB_ENV
-        ls -lAF node_modules/
     - name: Start Hubot, let plugins say hello & goodbye
       run: |
         cd $HUBOT_ROOT

--- a/.github/workflows/hubot-demo.yml
+++ b/.github/workflows/hubot-demo.yml
@@ -59,13 +59,6 @@ jobs:
     - name: Start Hubot, let plugins say hello & goodbye
       run: |
         cd $HUBOT_ROOT
-        echo "First run, initialise local storage"
-        PATH=$PATH:$( pwd )/node_modules/.bin
-        echo
-        echo "Second run"
-        # Log in and save creds to local storage, then exit.
-        HUBOT_FAREWELL_TIMEOUT=15000 hubot
-        # Reconnect with saved creds from local storage.
         hubot
 
     - name: Preserve artifacts

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
+      max-parallel: 1
 
     steps:
     - uses: actions/checkout@v2
@@ -34,6 +35,7 @@ jobs:
     - name: Integration Tests
       if: ${{ github.event_name == 'pull_request' }}
       env:
+        TEST_BOT_NAME: GHA_IntegrationTest_${{ github.run_id }}
         TEST_MATRIX_USER: ${{ secrets.TEST_MATRIX_USER }}
         TEST_MATRIX_PASSWORD: ${{ secrets.TEST_MATRIX_PASSWORD }}
         TEST_MATRIX_ROOM: ${{ secrets.TEST_MATRIX_ROOM }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
+        "@matrix-org/olm": "^3.2.15",
         "image-size": "^1.0.2",
         "matrix-js-sdk": "^37.4.0",
         "node-localstorage": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "src/matrix.mjs",
   "type": "module",
   "dependencies": {
+    "@matrix-org/olm": "^3.2.15",
     "image-size": "^1.0.2",
     "matrix-js-sdk": "^37.4.0",
     "node-localstorage": "^3.0.5",

--- a/src/adapter.integration.test.mjs
+++ b/src/adapter.integration.test.mjs
@@ -23,6 +23,7 @@ describe('Matrix Adapter Integration Tests', () => {
 
     process.env.HUBOT_MATRIX_HOST_SERVER = TEST_MATRIX_URL
     process.env.HUBOT_MATRIX_USER = TEST_MATRIX_USER
+    process.env.HUBOT_NAME = TEST_BOT_NAME
     process.env.HUBOT_MATRIX_PASSWORD = TEST_MATRIX_PASSWORD
 
     // Create test robot

--- a/src/adapter.integration.test.mjs
+++ b/src/adapter.integration.test.mjs
@@ -27,7 +27,7 @@ describe('Matrix Adapter Integration Tests', () => {
     process.env.HUBOT_MATRIX_PASSWORD = TEST_MATRIX_PASSWORD
 
     // Create test robot
-    robot = new Robot(null, 'mock-adapter', false, TEST_BOT_NAME)
+    robot = new Robot('mock-adapter', false, TEST_BOT_NAME)
 
     // Spy on robot methods
     robot.receive = jest.fn(robot.receive)

--- a/src/matrix.mjs
+++ b/src/matrix.mjs
@@ -73,7 +73,8 @@ export default {
                   that.handleUnknownDevices(error)
                   return that.robot.matrixClient.sendNotice(envelope.room, str)
                 }
-                console.error(error, 'error')
+                console.error(error.name, error)
+                throw error
               }))
             }
           }

--- a/src/matrix.mjs
+++ b/src/matrix.mjs
@@ -6,6 +6,7 @@ import request from 'request'
 import sizeOf from 'image-size'
 import MatrixSession from './session.mjs'
 import { LocalStorage } from 'node-localstorage'
+import '@matrix-org/olm'
 
 let localStorage
 if (localStorage == null) {
@@ -153,6 +154,14 @@ export default {
             return
           }
           that.robot.matrixClient = client
+
+          try {
+            await that.robot.matrixClient.initCrypto()
+            that.robot.logger.info('End-to-end encryption initialized successfully')
+          } catch (cryptoError) {
+            that.robot.logger.error(`Failed to initialize encryption: ${cryptoError.message}`)
+          }
+
           that.robot.matrixClient.on('sync', (state, prevState, data) => {
             switch (state) {
               case 'PREPARED':

--- a/src/matrix.mjs
+++ b/src/matrix.mjs
@@ -31,7 +31,8 @@ export default {
           this.robot.matrixClient.setPresence({ presence: 'online' })
             .catch(error => {
               if (error.errcode === 'M_LIMIT_EXCEEDED') {
-                this.robot.logger.warn(`Rate limited when setting presence. Retry after: ${error.retry_after_ms}ms`)
+                const waitMs = error.retry_after_ms || 10000
+                this.robot.logger.warn(`Rate limited when setting presence. Retry after: ${waitMs}ms`)
               } else {
                 this.robot.logger.warn(`Error ${error.errcode} setting presence: ${error.message}`)
               }

--- a/src/session.mjs
+++ b/src/session.mjs
@@ -3,6 +3,27 @@ import sdk from 'matrix-js-sdk'
 import { LocalStorageCryptoStore } from 'matrix-js-sdk/lib/crypto/store/localStorage-crypto-store.js'
 import Store from './store.mjs'
 
+function createMatrixCompatibleLogger(hubotLogger) {
+  return {
+    // Forward the basic logging methods
+    trace: (...args) => hubotLogger.debug(...args),
+    debug: (...args) => hubotLogger.debug(...args),
+    info: (...args) => hubotLogger.info(...args),
+    warn: (...args) => hubotLogger.warning(...args),
+    error: (...args) => hubotLogger.error(...args),
+
+    // Provide getChild method that matrix-js-sdk expects
+    getChild: (namespace) => {
+      return createMatrixCompatibleLogger({
+        debug: (...args) => hubotLogger.debug(`[${namespace}]`, ...args),
+        info: (...args) => hubotLogger.info(`[${namespace}]`, ...args),
+        warning: (...args) => hubotLogger.warning(`[${namespace}]`, ...args),
+        error: (...args) => hubotLogger.error(`[${namespace}]`, ...args)
+      })
+    }
+  }
+}
+
 export default class MatrixSession {
   constructor (botName, matrixServer, matrixUser, matrixPassword, logger, localStorage) {
     this.botName = botName
@@ -14,6 +35,9 @@ export default class MatrixSession {
     this.clientDefaultOptions = {
       store: new Store(this.localStorage),
       cryptoStore: new LocalStorageCryptoStore(localStorage),
+      // Enable crypto during client creation
+      useE2eForGroupCall: false,
+      fallbackICEServerAllowed: false,
       cryptoCallbacks: {
         getCrossSigningKey: (type) => null,
         onSecretRequested: (userId, deviceId, requestId, secretName) => {
@@ -22,7 +46,7 @@ export default class MatrixSession {
         },
         saveCrossSigningKeys: (keys) => {}
       },
-      logger: this.logger
+      logger: createMatrixCompatibleLogger(this.logger)
     }
   }
 
@@ -69,7 +93,7 @@ export default class MatrixSession {
       // Remove?
       that.localStorage.setItem('bot_name', that.botName)
 
-      // Re-initialise the client.
+      // Re-initialise the client with crypto support
       that.client = sdk.createClient({
         baseUrl: that.matrixServer || 'https://matrix-client.matrix.org',
         accessToken: data.access_token,

--- a/src/session.mjs
+++ b/src/session.mjs
@@ -28,9 +28,10 @@ export default class MatrixSession {
 
   createClient (cb) {
     const accessToken = this.localStorage.getItem('access_token')
-    const botName = this.localStorage.getItem('bot_name')
     const deviceId = this.localStorage.getItem('device_id')
     const userId = this.localStorage.getItem('user_id')
+    // Remove?
+    const botName = this.localStorage.getItem('bot_name')
 
     if (!accessToken || !botName || !deviceId || !userId) {
       this.logger.debug('Creating a new session: no authentication token can be found in local storage.')
@@ -63,9 +64,10 @@ export default class MatrixSession {
       that.logger.debug(`Logged in ${data.user_id} on device ${data.device_id}`)
 
       that.localStorage.setItem('access_token', data.access_token)
-      that.localStorage.setItem('bot_name', that.botName)
       that.localStorage.setItem('user_id', data.user_id)
       that.localStorage.setItem('device_id', data.device_id)
+      // Remove?
+      that.localStorage.setItem('bot_name', that.botName)
 
       // Re-initialise the client.
       that.client = sdk.createClient({

--- a/src/session.unit.test.mjs
+++ b/src/session.unit.test.mjs
@@ -48,9 +48,10 @@ describe('if no authentication token is available in the local storage', () => {
 
     matrixSession.createClient(jest.fn(() => {
       expect(localStorageMock.getItem('access_token')).toEqual('someAccessToken')
-      expect(localStorageMock.getItem('bot_name')).toEqual('juliasbot')
       expect(localStorageMock.getItem('user_id')).toEqual('someUserId')
       expect(localStorageMock.getItem('device_id')).toEqual('someDeviceId')
+      // Remove?
+      expect(localStorageMock.getItem('bot_name')).toEqual('juliasbot')
       done()
     }))
   })
@@ -64,9 +65,10 @@ test('no client login if authentication token is available in the local storage'
 
   const localStorageMock = new LocalStorageMock()
   localStorageMock.setItem('access_token', 'someAccessToken')
-  localStorageMock.setItem('bot_name', 'someBotName')
   localStorageMock.setItem('user_id', 'someUserId')
   localStorageMock.setItem('device_id', 'someDeviceId')
+  // Remove?
+  localStorageMock.setItem('bot_name', 'someBotName')
 
   const matrixSession = new MatrixSession('juliasbot', 'http://server:8080', 'julia',
     '123', logger, localStorageMock)


### PR DESCRIPTION
The start of this trail was that clients would connect and change their name, but not send or receive messages.

What it looks like is that on first connection, the client doesn't set up crypto correctly, so sync exchanges are rejected in an encrypted channel. What I observe is that If the client disconnects and reconnects, creds preserved in localStorage from the first run allows the connection to support crypto.

- It's possible this is an initialisation issue, and that some change to the init would make it work first pop.
- It's possible that this is a timing issue only; might be that crypto inits OK on the first run, but that the sync kicks off before crypto is initialised.

"Hubot demo" job on this PR fails because I've removed a workaround which was in place on that job. (Previously, Hubot was started, exited, and then started a second time, allowing channel messages to be sent with the creds preserved on first run in local storage.)

Unlike messages, name changes appear to not require encryption, so these tests set connecting client names to run-unique (ish) names, allowing me to observe which clients are successfully connecting from the test channel.

- [ ] Integration test should be GHA_IntegrationTest_12345
- [ ] Hubot demo should be GHA_HubotDemo_12345
- [ ] Is `src/crypto-polyfill.mjs` required?
- [ ] Remove unnecessary logging when done
- [ ] Improve integration test comments - refer to README
- [ ] Check init of MatrixSession in "Matrix Session Integration Tests: should connect to Matrix server and authenticate"
- [ ] Could we support init with an accesstoken here?
- [ ] Do we need to delete unused accessTokens, or set a short lifetime on them? (I ran into an error where the CI environment was downloading 50 device IDs, `/home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/matrix-sdk-crypto-0.11.1/src/identities/manager.rs:1206`, `DEBUG matrix_sdk_crypto::identities::manager: Finished handling of the `/keys/query` response`)