### PR TITLE
Jest --forceExit and reduced wait times

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -2,7 +2,7 @@
   "testMatch": [
     "**/*.test.mjs"
   ],
-  "testTimeout": 30000,
+  "testTimeout": 10000,
   "detectOpenHandles": true,
   "setupFiles": [
     "./jest-setup.js"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "standard",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:unit": "node --experimental-vm-modules node_modules/jest/bin/jest.js --testPathIgnorePatterns='.*\\.integration\\.test\\.mjs'",
-    "test:integration": "node --experimental-vm-modules node_modules/jest/bin/jest.js --testMatch='**/*.integration.test.mjs'"
+    "test:integration": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit --testMatch='**/*.integration.test.mjs'"
   },
   "engines": {
     "node": ">=18"

--- a/src/adapter.integration.test.mjs
+++ b/src/adapter.integration.test.mjs
@@ -62,7 +62,7 @@ describe('Matrix Adapter Integration Tests', () => {
 
     // Run the adapter
     adapter.run()
-  }, 30000)
+  }, 10000)
 
   test('should send a message to a room', async () => {
     if (!runIntegrationTests) return
@@ -91,5 +91,5 @@ describe('Matrix Adapter Integration Tests', () => {
         reject(error)
       }
     })
-  }, 30000)
+  }, 10000)
 })

--- a/src/session.integration.test.mjs
+++ b/src/session.integration.test.mjs
@@ -110,7 +110,7 @@ describe('Matrix Session Integration Tests', () => {
       // Clear the timeout to prevent open handles
       if (timeoutId) clearTimeout(timeoutId)
     }
-  }, 30000)
+  }, 10000)
 
   test('should sync rooms with the server', async () => {
     if (!runIntegrationTests) return
@@ -125,7 +125,7 @@ describe('Matrix Session Integration Tests', () => {
         console.warn('Sync timeout - continuing test anyway')
         matrixClient.removeListener('sync', onSync)
         resolve()
-      }, 25000)
+      }, 10000)
 
       const onSync = (state) => {
         console.log(`Sync state: ${state}`)
@@ -154,5 +154,5 @@ describe('Matrix Session Integration Tests', () => {
     await syncPromise
 
     expect(matrixClient).toBeDefined()
-  }, 60000) // Allow 60s for network operations.
+  }, 10000) // Allow 60s for network operations.
 })


### PR DESCRIPTION
Reducing some test wait times, adding `jest --forceExit`

https://github.com/matrix-org/matrix-js-sdk/issues/2472#issuecomment-1574098765

These timeouts might be a bit low (failed on one run of three), can bump back up depending on how this goes.